### PR TITLE
Increased curl timeout to 10 seconds, for the following case:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,3 +1248,13 @@ $api = new Binance\API("<key>", "<secret>", ['useServerTime'=>true]);
 //Call this before running any functions
 $api->useServerTime();
 ```
+
+#### Basic stats: Get api call counter
+```php
+$api->getRequestCount();
+```
+
+#### Basic stats: Get total data transfered
+```php
+$api->getTransfered();
+```

--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -201,7 +201,7 @@ class API {
 		// headers will proceed the output, json_decode will fail below
 		curl_setopt($ch, CURLOPT_HEADER, false);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		$output = curl_exec($ch);
 
 		// Check if any error occurred


### PR DESCRIPTION
 - Curl error: Operation timed out after 3000 milliseconds with 123458 bytes received
 - PHP Notice:  Undefined variable: openTime in php-binance-api.php on line 400

Update readme for stats methods