### PR TITLE
Add From ID for Orders and Trades

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -82,10 +82,10 @@ class API {
 		return $this->httpRequest("v3/openOrders","GET", ["symbol"=>$symbol], true);
 	}
 	public function orders($symbol, $limit = 500, $fromOrderId = 1) {
-		return $this->signedRequest("v3/allOrders", ["symbol"=>$symbol, "limit"=>$limit, "orderId"=>$orderId]);
+		return $this->httpRequest("v3/allOrders", "GET", ["symbol"=>$symbol, "limit"=>$limit, "orderId"=>$orderId], true);
 	}
 	public function history($symbol, $limit = 500, $fromTradeId = 1) {
-		return $this->signedRequest("v3/myTrades", ["symbol"=>$symbol, "limit"=>$limit, "fromId"=>$fromId]);
+		return $this->httpRequest("v3/myTrades", "GET", ["symbol"=>$symbol, "limit"=>$limit, "fromId"=>$fromId], true);
 	}	
 	public function useServerTime() {
 		$serverTime = $this->httpRequest("v1/time")['serverTime'];

--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -82,10 +82,10 @@ class API {
 		return $this->httpRequest("v3/openOrders","GET", ["symbol"=>$symbol], true);
 	}
 	public function orders($symbol, $limit = 500, $fromOrderId = 1) {
-		return $this->httpRequest("v3/allOrders", "GET", ["symbol"=>$symbol, "limit"=>$limit, "orderId"=>$orderId], true);
+		return $this->httpRequest("v3/allOrders", "GET", ["symbol"=>$symbol, "limit"=>$limit, "orderId"=>$fromOrderId], true);
 	}
 	public function history($symbol, $limit = 500, $fromTradeId = 1) {
-		return $this->httpRequest("v3/myTrades", "GET", ["symbol"=>$symbol, "limit"=>$limit, "fromId"=>$fromId], true);
+		return $this->httpRequest("v3/myTrades", "GET", ["symbol"=>$symbol, "limit"=>$limit, "fromId"=>$fromTradeId], true);
 	}	
 	public function useServerTime() {
 		$serverTime = $this->httpRequest("v1/time")['serverTime'];

--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -81,12 +81,12 @@ class API {
 	public function openOrders($symbol) {
 		return $this->httpRequest("v3/openOrders","GET", ["symbol"=>$symbol], true);
 	}
-	public function orders($symbol, $limit = 500) {
-		return $this->httpRequest("v3/allOrders", "GET", ["symbol"=>$symbol, "limit"=>$limit], true);
+	public function orders($symbol, $limit = 500, $fromOrderId = 1) {
+		return $this->signedRequest("v3/allOrders", ["symbol"=>$symbol, "limit"=>$limit, "orderId"=>$orderId]);
 	}
-	public function history($symbol, $limit = 500) {
-		return $this->httpRequest("v3/myTrades", "GET", ["symbol"=>$symbol, "limit"=>$limit], true);
-	}
+	public function history($symbol, $limit = 500, $fromTradeId = 1) {
+		return $this->signedRequest("v3/myTrades", ["symbol"=>$symbol, "limit"=>$limit, "fromId"=>$fromId]);
+	}	
 	public function useServerTime() {
 		$serverTime = $this->httpRequest("v1/time")['serverTime'];
 		$this->info['timeOffset'] = $serverTime - (microtime(true)*1000);


### PR DESCRIPTION
I added $fromOrderId and $fromTradeId to the respective functions as parameters.

Binance supports this and makes it easier to just get the most recent IDs.  The default is set to 1, if ommited, that means it will return all trades or orders since Binance is sequential with IDs.

Thanks