### PR TITLE
Fix an issue $symbol isn't displayed in the error message of the websocket

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -588,7 +588,7 @@ class API {
 			if ( !isset($this->depthQueue[$symbol]) ) $this->depthQueue[$symbol] = [];
 			if ( !isset($this->depthCache[$symbol]) ) $this->depthCache[$symbol] = ["bids" => [], "asks" => []];
 			$this->info[$symbol]['firstUpdate'] = 0;
-			$connector('wss://stream.binance.com:9443/ws/'.strtolower($symbol).'@depth')->then(function($ws) use($callback) {
+			$connector('wss://stream.binance.com:9443/ws/'.strtolower($symbol).'@depth')->then(function($ws) use($callback, $symbol) {
 				$ws->on('message', function($data) use($ws, $callback) {
 					$json = json_decode($data, true);
 					$symbol = $json['s'];
@@ -599,7 +599,7 @@ class API {
 					$this->depthHandler($json);
 					call_user_func($callback, $this, $symbol, $this->depthCache[$symbol]);
 				});
-				$ws->on('close', function($code = null, $reason = null) {
+				$ws->on('close', function($code = null, $reason = null) use($symbol) {
 					echo "depthCache({$symbol}) WebSocket Connection closed! ({$code} - {$reason})".PHP_EOL;
 				});
 			}, function($e) use($loop) {
@@ -625,7 +625,7 @@ class API {
 		foreach ( $symbols as $symbol ) {
 			if ( !isset($this->info[$symbol]) ) $this->info[$symbol] = [];
 			//$this->info[$symbol]['tradesCallback'] = $callback;
-			$connector('wss://stream.binance.com:9443/ws/'.strtolower($symbol).'@aggTrade')->then(function($ws) use($callback) {
+			$connector('wss://stream.binance.com:9443/ws/'.strtolower($symbol).'@aggTrade')->then(function($ws) use($callback, $symbol) {
 				$ws->on('message', function($data) use($ws, $callback) {
 					$json = json_decode($data, true);
 					$symbol = $json['s'];
@@ -637,7 +637,7 @@ class API {
 					//$this->info[$symbol]['tradesCallback']($this, $symbol, $trades);
 					call_user_func($callback, $this, $symbol, $trades);
 				});
-				$ws->on('close', function($code = null, $reason = null) {
+				$ws->on('close', function($code = null, $reason = null) use($symbol) {
 					echo "trades({$symbol}) WebSocket Connection closed! ({$code} - {$reason})".PHP_EOL;
 				});
 			}, function($e) use($loop) {
@@ -687,7 +687,7 @@ class API {
 			$this->chartQueue[$symbol][$interval] = [];
 			$this->info[$symbol][$interval]['firstOpen'] = 0;
 			//$this->info[$symbol]['chartCallback'.$interval] = $callback;
-			$connector('wss://stream.binance.com:9443/ws/'.strtolower($symbol).'@kline_'.$interval)->then(function($ws) use($callback) {
+			$connector('wss://stream.binance.com:9443/ws/'.strtolower($symbol).'@kline_'.$interval)->then(function($ws) use($callback, $symbol) {
 				$ws->on('message', function($data) use($ws, $callback) {
 					$json = json_decode($data);
 					$chart = $json->k;
@@ -697,7 +697,7 @@ class API {
 					//$this->info[$symbol]['chartCallback'.$interval]($this, $symbol, $this->charts[$symbol][$interval]);
 					call_user_func($callback, $this, $symbol, $this->charts[$symbol][$interval]);
 				});
-				$ws->on('close', function($code = null, $reason = null) {
+				$ws->on('close', function($code = null, $reason = null) use($symbol) {
 					echo "chart({$symbol},{$interval}) WebSocket Connection closed! ({$code} - {$reason})".PHP_EOL;
 				});
 			}, function($e) use($loop) {


### PR DESCRIPTION
Currently, $symbol isn't displayed correctly in the error message displayed when the websocket connection is closed. 
In order to make it work as expected, this PR changes the code to pass $symbol to the close event handler as a closure variable. 

