### PR TITLE
Output error message in httpRequest() only if $httpDebug is true

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -959,14 +959,18 @@ class API
         // Check if any error occurred
         if (curl_errno($curl) > 0) {
             // WPCS: XSS OK.
-            echo 'Curl error: ' . curl_error($curl) . "\n";
+            if($this->httpDebug) {
+                echo 'Curl error: ' . curl_error($curl) . "\n";
+            }
             return [];
         }
         curl_close($curl);
         $json = json_decode($output, true);
         if (isset($json['msg'])) {
             // WPCS: XSS OK.
-            echo "signedRequest error: {$output}" . PHP_EOL;
+            if($this->httpDebug) {
+                echo "signedRequest error: {$output}" . PHP_EOL;
+            }
         }
         $this->transfered += strlen($output);
         $this->requestCount++;


### PR DESCRIPTION
The httpRequest() function always outputs errors, even if `$this->httpDebug` is set to false, which disables curl output.
Now this error output is only shown, if `$this->httpDebug` is set to true.