### PR TITLE
Add price method to get the current price of a specific symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,10 @@ $api = new Binance\API( "somefile.json" );
 $api->caOverride = true;
 ```
 
-#### Get latest price of a symbol
+#### Get latest price of all symbols
 ```php
 $ticker = $api->prices();
-print_r($ticker); // List prices of all symbols
-echo "Price of BNB: {$ticker['BNBBTC']} BTC.".PHP_EOL;
+print_r($ticker);
 ```
 
 <details>
@@ -172,7 +171,13 @@ Price of BNB: 0.00021479 BTC.
 ```
 </details>
 
-### Get miniTicker for all symbols
+#### Get latest price of a symbol
+```php
+$price = $api->price("BNBBTC");
+echo "Price of BNB: {$price} BTC.".PHP_EOL;
+```
+
+#### Get miniTicker for all symbols
 ```php
 $api->miniTicker(function($api, $ticker) {
 	print_r($ticker);

--- a/examples/0.example.php
+++ b/examples/0.example.php
@@ -2,13 +2,16 @@
 require '../vendor/autoload.php';
 $api = new Binance\API("<api key>","<secret>");
 
+// Get latest price of all symbols
+$tickers = $api->prices();
+print_r($tickers); // List prices of all symbols
+
 // Get latest price of a symbol
-$ticker = $api->prices();
-print_r($ticker); // List prices of all symbols
-echo "Price of BNB: {$ticker['BNBBTC']} BTC.\n";
+$price = $api->price('BNBBTC');
+echo "Price of BNB: {$price} BTC.\n";
 
 // Get all of your positions, including estimated BTC value
-$balances = $api->balances($ticker);
+$balances = $api->balances($tickers);
 print_r($balances);
 
 // Get all bid/ask prices

--- a/examples/get_prices.php
+++ b/examples/get_prices.php
@@ -6,7 +6,10 @@ require '../php-binance-api.php';
 // use config from ~/.confg/jaggedsoft/php-binance-api.json
 $api = new Binance\API();
 
+// Get latest price of all symbols
+$tickers = $api->prices();
+print_r($tickers); // List prices of all symbols
+
 // Get latest price of a symbol
-$ticker = $api->prices();
-print_r($ticker); // List prices of all symbols
-echo "Price of BNB: {$ticker['BNBBTC']} BTC.\n";
+$price = $api->price('BNBBTC');
+echo "Price of BNB: {$price} BTC.\n";

--- a/examples/home_directory_config.php
+++ b/examples/home_directory_config.php
@@ -13,6 +13,5 @@ cat >  ~/.config/jaggedsoft/php-binance-api.json << EOF
 
 $api = new Binance\API();
 
-$ticker = $api->prices();
-print_r($ticker); // List prices of all symbols
-echo "Price of BNB: {$ticker['BNBBTC']} BTC.".PHP_EOL;
+$tickers = $api->prices();
+print_r($tickers); // List prices of all symbols

--- a/examples/proxy_config.php
+++ b/examples/proxy_config.php
@@ -14,12 +14,11 @@ $proxyConf = [
 // use config from ~/.confg/jaggedsoft/php-binance-api.json
 $api = new Binance\API("","",["useServerTime"=>false],$proxyConf);
 
-$ticker = $api->prices();
-print_r($ticker); // List prices of all symbols
-echo "Price of BNB: {$ticker['BNBBTC']} BTC.".PHP_EOL;
+$tickers = $api->prices();
+print_r($tickers); // List prices of all symbols
 
 // Get balances for all of your positions, including estimated BTC value
-$balances = $api->balances($ticker);
+$balances = $api->balances($tickers);
 print_r($balances);
 echo "BTC owned: ".$balances['BTC']['available'].PHP_EOL;
 echo "ETH owned: ".$balances['ETH']['available'].PHP_EOL;

--- a/examples/ratelimiter.php
+++ b/examples/ratelimiter.php
@@ -8,8 +8,8 @@ $api = new Binance\API();
 $api = new Binance\RateLimiter($api);
 
 // Get latest price of a symbol
-$ticker = $api->prices();
-echo "Price of BNB: {$ticker['BNBBTC']} BTC.\n";
+$price = $api->price("BNBBTC");
+echo "Price of BNB: {$price} BTC.\n";
 
 while(true)
 {

--- a/examples/single/single.php
+++ b/examples/single/single.php
@@ -3,12 +3,16 @@
 require 'binance-api-single.php';
 $api = new Binance("<key>","<secret>");
 
-$ticker = $api->prices();
-print_r($ticker); // List prices of all symbols 
-echo "Price of BNB: {$ticker['BNBBTC']} BTC.".PHP_EOL;
+// Get latest price of all symbols
+$tickers = $api->prices();
+print_r($tickers); // List prices of all symbols
+
+// Get latest price of a symbol
+$price = $api->price("BNBBTC");
+echo "Price of BNB: {$price} BTC.".PHP_EOL;
 
 // Get balances for all of your positions, including estimated BTC value
-$balances = $api->balances($ticker);
+$balances = $api->balances($tickers);
 print_r($balances);
 echo "BTC owned: ".$balances['BTC']['available'].PHP_EOL;
 echo "ETH owned: ".$balances['ETH']['available'].PHP_EOL;

--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -630,6 +630,21 @@ class API
     }
 
     /**
+     * price get the latest price of a symbol
+     *
+     * $price = $api->price( "ETHBTC" );
+     *
+     * @return array with error message or array with symbol price
+     * @throws \Exception
+     */
+    public function price(string $symbol)
+    {
+        $ticker = $this->httpRequest("v3/ticker/price", "GET", ["symbol" => $symbol]);
+
+        return $ticker['price'];
+    }
+
+    /**
      * bookPrices get all bid/asks prices
      *
      * $ticker = $api->bookPrices();


### PR DESCRIPTION
It feels overkill to have to download the prices of _all_ of Binance's supported symbols when interested in a specific one only, especially when Binance's API allows to target a single symbol already. The response's payload is consequently unnecessary big.

This PR adds a new `price` method under the existing `prices` one, requiring a symbol. The `README` and examples were updated accordingly.