### PR TITLE
Add limit parameter for market depth method

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -723,17 +723,21 @@ class API
      * $depth = $api->depth("ETHBTC");
      *
      * @param $symbol string the symbol to get the depth information for
+     * @param $limit int set limition for number of market depth data
      * @return array with error message or array of market depth
      * @throws \Exception
      */
-    public function depth(string $symbol)
+    public function depth(string $symbol, int $limit)
     {
+	if (isset($limit) === false || is_int($limit) === false)
+		$limit = 100;
         if (isset($symbol) === false || is_string($symbol) === false) {
             // WPCS: XSS OK.
             echo "asset: expected bool false, " . gettype($symbol) . " given" . PHP_EOL;
         }
         $json = $this->httpRequest("v1/depth", "GET", [
             "symbol" => $symbol,
+	    "limit" => $limit,
         ]);
         if (isset($this->info[$symbol]) === false) {
             $this->info[$symbol] = [];


### PR DESCRIPTION
Hello,
I've added ability to set limitation for market depth request according to official [Binance API doc](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#market-data-endpoints) .
Now we have an optional "limit" parameter when we call depth() method.

Example:
`$depth = $api->depth("ETHBTC",10);`