### PR TITLE
fix numberOfDecimals

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -334,8 +334,8 @@ class API
      * @param $val float the minimum order amount for the pair
      * @return integer (signifcant digits) based on the minimum order amount
      */
-    public function numberOfDecimals($val = 0.00000001) {
-        $val = sprintf("%.18f", $val);
+    public function numberOfDecimals($val = 0.00000001){
+        $val = sprintf("%.14f", $val);
         $parts = explode('.', $val); 
         $parts[1] = rtrim($parts[1], "0");
         return strlen($parts[1]);


### PR DESCRIPTION
https://www.php.net/manual/en/language.types.float.php

The size of a float is platform-dependent, although a maximum of approximately 1.8e308 with a precision of roughly 14 decimal digits is a common value (the 64 bit IEEE format).

Before:
http://sandbox.onlinephpfunctions.com/code/77a12ad6860ec0d5ff3626f3b8cfd44b1a1ed8cb

After:
http://sandbox.onlinephpfunctions.com/code/3c4d9653a2d4ed0ee24f3d534d3565c5ad298551