### PR TITLE
Fixing __call for non api functions + Access Binance response headers about x-mbx-used-weight and x-mbx-used-weight-1m

### DIFF
--- a/php-binance-api-rate-limiter.php
+++ b/php-binance-api-rate-limiter.php
@@ -236,9 +236,9 @@ class RateLimiter
      */
     public function __call(string $name, array $arguments)
     {
-        $weight = $this->weights[$name];
+        $weight = $this->weights[$name] ?? false;
 
-        if ($weight > 0) {
+        if ($weight && $weight > 0) {
             $this->requestsPerMinute();
             if (in_array($name, $this->ordersfunctions) === true) {
                 $this->ordersPerSecond();

--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -53,7 +53,10 @@ class API
     
     protected $exchangeInfo = NULL;
     protected $lastRequest = [];
-    
+
+    private $xMbxUsedWeight = 0;
+    private $xMbxUsedWeight1m = 0;
+
     /**
      * Constructor for the class,
      * send as many argument as you want.
@@ -1015,7 +1018,15 @@ class API
             'header' => $header,
             'json' => $json
         ];
-        
+
+        if (isset($header['x-mbx-used-weight'])) {
+            $this->setXMbxUsedWeight($header['x-mbx-used-weight']);
+        }
+
+        if (isset($header['x-mbx-used-weight-1m'])) {
+            $this->setXMbxUsedWeight1m($header['x-mbx-used-weight-1m']);
+        }
+
         if(isset($json['msg'])){
             // should always output error, not only on httpdebug
             // not outputing errors, hides it from users and ends up with tickets on github
@@ -2346,6 +2357,23 @@ class API
     private function floorDecimal($n, $decimals=2)
     {   
         return floor($n * pow(10, $decimals)) / pow(10, $decimals);
+    }
+
+
+    private function setXMbxUsedWeight (int $usedWeight) : void {
+        $this->xMbxUsedWeight = $usedWeight;
+    }
+
+    private function setXMbxUsedWeight1m (int $usedWeight1m) : void {
+        $this->xMbxUsedWeight1m = $usedWeight1m;
+    }
+
+    public function getXMbxUsedWeight () : int {
+        $this->xMbxUsedWeight;
+    }
+
+    public function getXMbxUsedWeight1m () : int {
+        $this->xMbxUsedWeight1m;
     }
     
 }


### PR DESCRIPTION
I had warning when using the methods "roundTicks" and "roundStep".

When using the RateLimiter, those methods doesn't have weight in the private array of RateLimiter class. Therefore, a warning was displayed.

By testing $weight variable and setting it to false if no weight is found in the array, we have no more warning messages.

This code is PHP7.0+ proof.