### PR TITLE
Expect an empty array for account balances

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -832,8 +832,9 @@ class API
             echo "Error: unable to fetch your account details" . PHP_EOL;
         }
 
-        if (isset($account['balances']) === false) {
+        if (isset($account['balances']) === false || empty($account['balances'])) {
             echo "Error: your balances were empty or unset" . PHP_EOL;
+	    return [];
         }
 
         return $this->balanceData($account, $priceData);


### PR DESCRIPTION
With a new Binance account, the API returns an empty array for the `balances`. This causes some misleading error messages to be shown, saying things about `useServerTime()` and faulty credentials.