### PR TITLE
The SAPI , in the successful state return empty msg

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -1056,7 +1056,7 @@ class API
             $this->setXMbxUsedWeight1m($header['x-mbx-used-weight-1m']);
         }
 
-        if(isset($json['msg'])){
+        if(isset($json['msg']) && !empty($json['msg'])){
             // should always output error, not only on httpdebug
             // not outputing errors, hides it from users and ends up with tickets on github
             throw new \Exception('signedRequest error: '.print_r($output, true));


### PR DESCRIPTION
This part return Exception:
if(isset($json['msg']){
throw new \Exception('signedRequest error: '.print_r($output, true));
}
https://binance-docs.github.io/apidocs/spot/en/#daily-account-snapshot-user_data