### PR TITLE
symbol is mandatory for history

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -563,7 +563,6 @@ class API
     /**
      * history Get the complete account trade history for all or a specific currency
      *
-     * $allHistory = $api->history();
      * $BNBHistory = $api->history("BNBBTC");
      * $limitBNBHistory = $api->history("BNBBTC",5);
      * $limitBNBHistoryFromId = $api->history("BNBBTC",5,3);


### PR DESCRIPTION
As per https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#account-trade-list-user_data