### PR TITLE
Set $callable to null but throw Exception if it is null

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -12,6 +12,8 @@
  */
 namespace Binance;
 
+use Exception;
+
 // PHP version check
 if (version_compare(phpversion(), '7.0', '<=')) {
     fwrite(STDERR, "Hi, PHP " . phpversion() . " support will be removed very soon as part of continued development.\n");
@@ -55,7 +57,7 @@ class API
 
     // /< value of available onOrder assets
     
-    protected $exchangeInfo = NULL;
+    protected $exchangeInfo = null;
     protected $lastRequest = [];
 
     protected $xMbxUsedWeight = 0;
@@ -374,8 +376,8 @@ class API
     {
         return $this->order("BUY", $symbol, $quantity, 0, "MARKET", $flags, true);
     }
-	
-	
+    
+    
     /**
      * numberOfDecimals() returns the signifcant digits level based on the minimum order amount.
      *
@@ -384,9 +386,10 @@ class API
      * @param $val float the minimum order amount for the pair
      * @return integer (signifcant digits) based on the minimum order amount
      */
-    public function numberOfDecimals($val = 0.00000001){
+    public function numberOfDecimals($val = 0.00000001)
+    {
         $val = sprintf("%.14f", $val);
-        $parts = explode('.', $val); 
+        $parts = explode('.', $val);
         $parts[1] = rtrim($parts[1], "0");
         return strlen($parts[1]);
     }
@@ -553,10 +556,13 @@ class API
      * @return array with error message or array of orderDetails array
      * @throws \Exception
      */
-    public function orders(string $symbol, int $limit = 500, int $fromOrderId = 0, array $params = []) {
-	$params["symbol"] = $symbol;
-	$params["limit"] = $limit;
-        if ( $fromOrderId ) $params["orderId"] = $fromOrderId;
+    public function orders(string $symbol, int $limit = 500, int $fromOrderId = 0, array $params = [])
+    {
+        $params["symbol"] = $symbol;
+        $params["limit"] = $limit;
+        if ($fromOrderId) {
+            $params["orderId"] = $fromOrderId;
+        }
         return $this->httpRequest("v3/allOrders", "GET", $params, true);
     }
 
@@ -625,17 +631,15 @@ class API
      */
     public function exchangeInfo()
     {
-        if(!$this->exchangeInfo){
-            
+        if (!$this->exchangeInfo) {
             $arr = $this->httpRequest("v1/exchangeInfo");
             
             $this->exchangeInfo = $arr;
             $this->exchangeInfo['symbols'] = null;
             
-            foreach($arr['symbols'] as $key => $value){
+            foreach ($arr['symbols'] as $key => $value) {
                 $this->exchangeInfo['symbols'][$value['symbol']] = $value;
             }
-            
         }
         
         return $this->exchangeInfo;
@@ -646,13 +650,13 @@ class API
         $params["wapi"] = true;
         return $this->httpRequest("v3/assetDetail.html", 'GET', $params, true);
     }
-	
+    
     public function userAssetDribbletLog()
     {
         $params["wapi"] = true;
         return $this->httpRequest("v3/userAssetDribbletLog.html", 'GET', $params, true);
     }
-	
+    
     /**
      * Fetch current(daily) trade fee of symbol, values in percentage.
      * for more info visit binance official api document
@@ -663,11 +667,11 @@ class API
      */
     public function tradeFee(string $symbol)
     {
-	$params = [
+        $params = [
             "symbol" => $symbol,
             "wapi" => true,
         ];
-	    
+        
         return $this->httpRequest("v3/tradeFee.html", 'GET', $params, true);
     }
 
@@ -691,7 +695,7 @@ class API
      * @return array with error message or array transaction
      * @throws \Exception
      */
-    public function withdraw(string $asset, string $address, $amount, $addressTag = null, $addressName = "", bool $transactionFeeFlag = false,$network = null)
+    public function withdraw(string $asset, string $address, $amount, $addressTag = null, $addressName = "", bool $transactionFeeFlag = false, $network = null)
     {
         $options = [
             "asset" => $asset,
@@ -883,7 +887,7 @@ class API
             "symbol" => $symbol,
         ]));
     }
-	
+    
     /**
      * historicalTrades Get historical trades for a specific currency
      *
@@ -908,7 +912,7 @@ class API
         }
         
         // The endpoint cannot handle extra parameters like 'timestamp' or 'signature',
-	// but it needs the http header with the key so we need to construct it here
+        // but it needs the http header with the key so we need to construct it here
         $query = http_build_query($parameters, '', '&');
         return $this->httpRequest("v3/historicalTrades?$query");
     }
@@ -967,7 +971,7 @@ class API
 
         if (isset($account['balances']) === false || empty($account['balances'])) {
             echo "Error: your balances were empty or unset" . PHP_EOL;
-	    return [];
+            return [];
         }
 
         return $this->balanceData($account, $priceData);
@@ -980,7 +984,8 @@ class API
      * @return array with error message or array containing coins
      * @throws \Exception
      */
-    public function coins(){
+    public function coins()
+    {
         return $this->httpRequest('v1/capital/config/getall', 'GET', [ 'sapi' => true ], true);
     }
 
@@ -1100,7 +1105,7 @@ class API
                 unset($params['wapi']);
                 $base = $this->wapi;
             }
-		
+        
             if (isset($params['sapi'])) {
                 if ($this->useTestnet) {
                     throw new \Exception("sapi endpoints are not available in testnet");
@@ -1108,13 +1113,13 @@ class API
                 unset($params['sapi']);
                 $base = $this->sapi;
             }
-		
+        
             $query = http_build_query($params, '', '&');
             $signature = hash_hmac('sha256', $query, $this->api_secret);
             if ($method === "POST") {
                 $endpoint = $base . $url;
-				$params['signature'] = $signature; // signature needs to be inside BODY
-				$query = http_build_query($params, '', '&'); // rebuilding query
+                $params['signature'] = $signature; // signature needs to be inside BODY
+                $query = http_build_query($params, '', '&'); // rebuilding query
             } else {
                 $endpoint = $base . $url . '?' . $query . '&signature=' . $signature;
             }
@@ -1125,7 +1130,7 @@ class API
             ));
         }
         // params so buildquery string and append to url
-        else if (count($params) > 0) {
+        elseif (count($params) > 0) {
             curl_setopt($curl, CURLOPT_URL, $this->getRestEndpoint() . $url . '?' . $query);
         }
         // no params so just the base url
@@ -1206,7 +1211,7 @@ class API
             $this->setXMbxUsedWeight1m($header['x-mbx-used-weight-1m']);
         }
 
-        if(isset($json['msg']) && !empty($json['msg'])){
+        if (isset($json['msg']) && !empty($json['msg'])) {
             // should always output error, not only on httpdebug
             // not outputing errors, hides it from users and ends up with tickets on github
             throw new \Exception('signedRequest error: '.print_r($output, true));
@@ -1390,7 +1395,7 @@ class API
                 $btc_value += $obj['free'];
                 $btc_total += $obj['free'] + $obj['locked'];
                 continue;
-            } elseif ( $asset === 'USDT' || $asset === 'USDC' || $asset === 'PAX' || $asset === 'BUSD' ) {
+            } elseif ($asset === 'USDT' || $asset === 'USDC' || $asset === 'PAX' || $asset === 'BUSD') {
                 $btcValue = $obj['free'] / $priceData['BTCUSDT'];
                 $btcTotal = ($obj['free'] + $obj['locked']) / $priceData['BTCUSDT'];
                 $balances[$asset]['btcValue'] = $btcValue;
@@ -1871,14 +1876,12 @@ class API
             if ($bid[1] == "0.00000000") {
                 unset($this->depthCache[$symbol]['bids'][$bid[0]]);
             }
-
         }
         foreach ($json['a'] as $ask) {
             $this->depthCache[$symbol]['asks'][$ask[0]] = $ask[1];
             if ($ask[1] == "0.00000000") {
                 unset($this->depthCache[$symbol]['asks'][$ask[0]]);
             }
-
         }
     }
 
@@ -2161,8 +2164,11 @@ class API
      * @return null
      * @throws \Exception
      */
-    public function chart($symbols, string $interval = "30m", callable $callback, $limit = 500)
+    public function chart($symbols, string $interval = "30m", callable $callback = null, $limit = 500)
     {
+        if (is_null($callback)) {
+            throw new Exception("You must provide a valid callback");
+        }
         if (!is_array($symbols)) {
             $symbols = [
                 $symbols,
@@ -2242,8 +2248,11 @@ class API
      * @return null
      * @throws \Exception
      */
-    public function kline($symbols, string $interval = "30m", callable $callback)
+    public function kline($symbols, string $interval = "30m", callable $callback = null)
     {
+        if (is_null($callback)) {
+            throw new Exception("You must provide a valid callback");
+        }
         if (!is_array($symbols)) {
             $symbols = [
                 $symbols,
@@ -2450,7 +2459,7 @@ class API
         // @codeCoverageIgnoreEnd
     }
 
-	/**
+    /**
      * bookTicker Get bookTicker for all symbols
      *
      * $api->bookTicker(function($api, $ticker) {
@@ -2460,7 +2469,7 @@ class API
      * @param $callback callable function closer that takes 2 arguments, $api and $ticker data
      * @return null
      */
-	public function bookTicker(callable $callback)
+    public function bookTicker(callable $callback)
     {
         $endpoint = '!bookticker';
         $this->subscriptions[$endpoint] = true;
@@ -2476,14 +2485,14 @@ class API
                 }
                 $json = json_decode($data, true);
 
-				$markets = [
-					"updateId"  => $json['u'],
-					"symbol"    => $json['s'],
-					"bid_price" => $json['b'],
-					"bid_qty"   => $json['B'],
-					"ask_price" => $json['a'],
-					"ask_qty"   => $json['A'],
-				];
+                $markets = [
+                    "updateId"  => $json['u'],
+                    "symbol"    => $json['s'],
+                    "bid_price" => $json['b'],
+                    "bid_qty"   => $json['B'],
+                    "ask_price" => $json['a'],
+                    "ask_qty"   => $json['A'],
+                ];
                 call_user_func($callback, $this, $markets);
             });
             $ws->on('close', function ($code = null, $reason = null) {
@@ -2547,36 +2556,43 @@ class API
     }
     
     protected function floorDecimal($n, $decimals=2)
-    {   
+    {
         return floor($n * pow(10, $decimals)) / pow(10, $decimals);
     }
 
 
-    protected function setXMbxUsedWeight (int $usedWeight) : void {
+    protected function setXMbxUsedWeight(int $usedWeight) : void
+    {
         $this->xMbxUsedWeight = $usedWeight;
     }
 
-    protected function setXMbxUsedWeight1m (int $usedWeight1m) : void {
+    protected function setXMbxUsedWeight1m(int $usedWeight1m) : void
+    {
         $this->xMbxUsedWeight1m = $usedWeight1m;
     }
 
-    public function getXMbxUsedWeight () : int {
+    public function getXMbxUsedWeight() : int
+    {
         $this->xMbxUsedWeight;
     }
 
-    public function getXMbxUsedWeight1m () : int {
+    public function getXMbxUsedWeight1m() : int
+    {
         $this->xMbxUsedWeight1m;
     }
 
-    private function getRestEndpoint() : string {
+    private function getRestEndpoint() : string
+    {
         return $this->useTestnet ? $this->baseTestnet : $this->base;
     }
 
-    private function getWsEndpoint() : string {
+    private function getWsEndpoint() : string
+    {
         return $this->useTestnet ? $this->streamTestnet : $this->stream;
     }
 
-    public function isOnTestnet() : bool {
+    public function isOnTestnet() : bool
+    {
         return $this->useTestnet;
     }
 }


### PR DESCRIPTION
Composer 2.0 and PHP 8.0 do not allow required parameters to come after optional parameters. 

An example of this in current use is 
```php
public function chart($symbols, string $interval = "30m", callable $callback, $limit = 500)
```
`$callback` would need to come before `$interval` for the new autoloading rules.

I have provided a fix by making `$callback` null but throwing an exception if it is *null*

PR also updates the code style of PSR-2