### PR TITLE
uasort should be DESC like before, not ASC

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -1426,7 +1426,7 @@ class API
             uasort($balances, function ($opA, $opB) {
                 if ($opA == $opB)
                     return 0;
-                return ($opA['btcValue'] < $opB['btcValue']) ? -1 : 1;
+                return ($opA['btcValue'] < $opB['btcValue']) ? 1 : -1;
             });
             $this->btc_value = $btc_value;
             $this->btc_total = $btc_total;


### PR DESCRIPTION
Pull request #350 fixed the PHP8 issue, but inversed the order. This pull request brings it back to descending order.