### PR TITLE
fix generate signatue

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -1121,6 +1121,7 @@ class API
             }
         
             $query = http_build_query($params, '', '&');
+            $query = str_replace([ '%40' ], [ '@' ], $query);//if send data type "e-mail" then binance return: [Signature for this request is not valid.]
             $signature = hash_hmac('sha256', $query, $this->api_secret);
             if ($method === "POST") {
                 $endpoint = $base . $url;


### PR DESCRIPTION
If send data type "e-mail" then binance return: [Signature for this request is not valid.]

When using the Binance Corporate API

If need to add functions for working with the Binance Corporate API, just tell me how to name the functions correctly =)

Now:
sub_accounts() - [/sapi/v1/sub-account/list]
sub_account_assets() - [...]
sub_account_deposit_address() - [...]
sub_account_deposits() - [...]
sub_account_transfer_universal() - [...]