### PR TITLE
Switch wapi tradeFee to sapi commissionFee

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -693,8 +693,30 @@ class API
             "symbol" => $symbol,
             "wapi" => true,
         ];
+        trigger_error('Function tradeFee is deprecated and will be removed from Binance on Aug 1, 2021. Please use $api->commissionFee', E_USER_NOTICE);
         
         return $this->httpRequest("v3/tradeFee.html", 'GET', $params, true);
+    }
+    
+    /**
+     * commissionFee - Fetch commission trade fee
+     * 
+     * @link https://binance-docs.github.io/apidocs/spot/en/#trade-fee-user_data
+     * 
+     * @property int $weight 1
+     * 
+     * @param string $symbol  (optional)  Should be a symbol, e.g. BNBUSDT or empty to get the full list
+     * 
+     * @return array containing the response
+     * @throws \Exception
+     */    
+    public function commissionFee($symbol = '')
+    {
+        $params = array('sapi' => true);
+        if ($symbol != '' && gettype($symbol) == 'string')
+            $params['symbol'] = $symbol;
+
+        return $this->httpRequest("v1/asset/tradeFee", 'GET', $params, true);
     }
 
     /**

--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -680,6 +680,8 @@ class API
     }
     
     /**
+     * @deprecated
+     *
      * Fetch current(daily) trade fee of symbol, values in percentage.
      * for more info visit binance official api document
      *
@@ -693,7 +695,7 @@ class API
             "symbol" => $symbol,
             "wapi" => true,
         ];
-        trigger_error('Function tradeFee is deprecated and will be removed from Binance on Aug 1, 2021. Please use $api->commissionFee', E_USER_NOTICE);
+        trigger_error('Function tradeFee is deprecated and will be removed from Binance on Aug 1, 2021. Please use $api->commissionFee', E_USER_DEPRECATED);
         
         return $this->httpRequest("v3/tradeFee.html", 'GET', $params, true);
     }


### PR DESCRIPTION
As per #363 WAPI endpoints will disappear on Aug 1.
The old tradeFee function remains available until Binance decommissions it, but a deprecated warning is sent.
The new commissionFee function allows now calling it without argument, showing the full list of all symbols with the fees.