### PR TITLE
added startTime and endTime parameters to myTrades request

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -576,10 +576,12 @@ class API
      * @param $symbol string the currency symbol
      * @param $limit int the amount of orders returned
      * @param $fromTradeId int (optional) return the orders from this order onwards. negative for all
+     * @param $startTime int (optional) return the orders from this time onwards. null to ignore
+     * @param $endTime int (optional) return the orders from this time backwards. null to ignore
      * @return array with error message or array of orderDetails array
      * @throws \Exception
      */
-    public function history(string $symbol, int $limit = 500, int $fromTradeId = -1)
+    public function history(string $symbol, int $limit = 500, int $fromTradeId = -1, int $startTime = null, int $endTime = null)
     {
         $parameters = [
             "symbol" => $symbol,
@@ -587,6 +589,12 @@ class API
         ];
         if ($fromTradeId > 0) {
             $parameters["fromId"] = $fromTradeId;
+        }
+        if (isset($startTime)) {
+            $parameters["startTime"] = $startTime;
+        }
+        if (isset($endTime)) {
+            $parameters["endTime"] = $endTime;
         }
 
         return $this->httpRequest("v3/myTrades", "GET", $parameters, true);


### PR DESCRIPTION
As stated in the [Binance RestApi Documentation](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#account-trade-list-user_data) there are two possible params ``startTime`` and ``endTime`` that allows to fetch the trades since and untill the given times. This is not only very useful, but necesary if you want to retrieve all the historical trades of a given account with many trades.

The modifications have been properly tested, and I took care of the backward compatibility.
Than you very much for the review!