### PR TITLE
Enable http_build_query to handle arrays

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -1222,7 +1222,7 @@ class API
 
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_VERBOSE, $this->httpDebug);
-        $query = $this->binance_build_query($params, '', '&');
+        $query = $this->binance_build_query($params);
 
         // signed with params
         if ($signed === true) {

--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -1253,13 +1253,13 @@ class API
                 $base = $this->sapi;
             }
         
-            $query = $this->binance_build_query($params, '', '&');
+            $query = $this->binance_build_query($params);
             $query = str_replace([ '%40' ], [ '@' ], $query);//if send data type "e-mail" then binance return: [Signature for this request is not valid.]
             $signature = hash_hmac('sha256', $query, $this->api_secret);
             if ($method === "POST") {
                 $endpoint = $base . $url;
                 $params['signature'] = $signature; // signature needs to be inside BODY
-                $query = $this->binance_build_query($params, '', '&'); // rebuilding query
+                $query = $this->binance_build_query($params); // rebuilding query
             } else {
                 $endpoint = $base . $url . '?' . $query . '&signature=' . $signature;
             }


### PR DESCRIPTION
The standard http_build_query cannot handle queries, but some Binance features like sapi v1/asset/dust can have an array.