### PR TITLE
apiRestrictions method added

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -2930,6 +2930,21 @@ class API
         $arr['sapi'] = $this->httpRequest("v1/account/status", 'GET', [ 'sapi' => true ], true);
         return $arr;
     }
+
+    /**
+     * apiRestriction - Fetch a set of API restrictions
+     *
+     * @link https://binance-docs.github.io/apidocs/spot/en/#get-api-key-permission-user_data
+     *
+     * @property int $weight 1
+     *
+     * @return array containing the response
+     * @throws \Exception
+     */
+    public function apiRestrictions()
+    {
+        return $this->httpRequest("v1/account/apiRestrictions", 'GET', ['sapi' => true], true);
+    }
     
     /**
      * apiTradingStatus - Fetch account API trading status detail.


### PR DESCRIPTION
API Restrictions info added (sapi). It returns information about permissions of your API Key and **trading authority expiration time**.
More info: https://binance-docs.github.io/apidocs/spot/en/#get-api-key-permission-user_data
Example of the response:
```
Array
(
    [ipRestrict] => 
    [createTime] => 1640988000000
    [tradingAuthorityExpirationTime] => 1646085600000
    [enableSpotAndMarginTrading] => 1
    [enableFutures] => 
    [enableMargin] => 
    [enableReading] => 1
    [enableWithdrawals] => 
    [enableInternalTransfer] => 
    [permitsUniversalTransfer] => 
    [enableVanillaOptions] => 
)
```